### PR TITLE
Add support for compilation with MS-MPI SDK when cross-compiling

### DIFF
--- a/USER-AEAM/CMakeLists.txt
+++ b/USER-AEAM/CMakeLists.txt
@@ -48,10 +48,17 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
       set(mytarget package)
     endif()
     if(BUILD_MPI)
-      add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION}-MPI aeamplugin.nsis
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        DEPENDS aeamplugin ${CMAKE_BINARY_DIR}/lammps.ico ${CMAKE_BINARY_DIR}/lammps-text-logo-wide.bmp ${CMAKE_BINARY_DIR}/aeamplugin.nsis
-        BYPRODUCTS ${CMAKE_BINARY_DIR}/LAMMPS-USER-AEAM-plugin-${LAMMPS_VERSION}-MPI.exe)
+      if(USE_MSMPI)
+        add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION}-MSMPI aeamplugin.nsis
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+          DEPENDS aeamplugin ${CMAKE_BINARY_DIR}/lammps.ico ${CMAKE_BINARY_DIR}/lammps-text-logo-wide.bmp ${CMAKE_BINARY_DIR}/aeamplugin.nsis
+          BYPRODUCTS ${CMAKE_BINARY_DIR}/LAMMPS-USER-AEAM-plugin-${LAMMPS_VERSION}-MSMPI.exe)
+      else()
+        add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION}-MSMPI aeamplugin.nsis
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+          DEPENDS aeamplugin ${CMAKE_BINARY_DIR}/lammps.ico ${CMAKE_BINARY_DIR}/lammps-text-logo-wide.bmp ${CMAKE_BINARY_DIR}/aeamplugin.nsis
+          BYPRODUCTS ${CMAKE_BINARY_DIR}/LAMMPS-USER-AEAM-plugin-${LAMMPS_VERSION}-MPI.exe)
+      endif()
     else()
       add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION} aeamplugin.nsis
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/USER-AEAM/CMakeLists.txt
+++ b/USER-AEAM/CMakeLists.txt
@@ -48,7 +48,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
       set(mytarget package)
     endif()
     if(BUILD_MPI)
-      if(USE_MSMPI)
+      if(USE_MSMPI AND CMAKE_CROSSCOMPILING)
         add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION}-MSMPI aeamplugin.nsis
           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
           DEPENDS aeamplugin ${CMAKE_BINARY_DIR}/lammps.ico ${CMAKE_BINARY_DIR}/lammps-text-logo-wide.bmp ${CMAKE_BINARY_DIR}/aeamplugin.nsis

--- a/USER-REBOMOS/CMakeLists.txt
+++ b/USER-REBOMOS/CMakeLists.txt
@@ -48,7 +48,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
       set(mytarget package)
     endif()
     if(BUILD_MPI)
-      if(USE_MSMPI)
+      if(USE_MSMPI AND CMAKE_CROSSCOMPILING)
         add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION}-MSMPI rebomosplugin.nsis
           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
           DEPENDS rebomosplugin ${CMAKE_BINARY_DIR}/lammps.ico ${CMAKE_BINARY_DIR}/lammps-text-logo-wide.bmp ${CMAKE_BINARY_DIR}/rebomosplugin.nsis

--- a/USER-REBOMOS/CMakeLists.txt
+++ b/USER-REBOMOS/CMakeLists.txt
@@ -48,10 +48,17 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
       set(mytarget package)
     endif()
     if(BUILD_MPI)
-      add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION}-MPI rebomosplugin.nsis
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        DEPENDS rebomosplugin ${CMAKE_BINARY_DIR}/lammps.ico ${CMAKE_BINARY_DIR}/lammps-text-logo-wide.bmp ${CMAKE_BINARY_DIR}/aeamplugin.nsis
-        BYPRODUCTS ${CMAKE_BINARY_DIR}/LAMMPS-USER-REBOMOS-plugin-${LAMMPS_VERSION}-MPI.exe)
+      if(USE_MSMPI)
+        add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION}-MSMPI rebomosplugin.nsis
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+          DEPENDS rebomosplugin ${CMAKE_BINARY_DIR}/lammps.ico ${CMAKE_BINARY_DIR}/lammps-text-logo-wide.bmp ${CMAKE_BINARY_DIR}/rebomosplugin.nsis
+          BYPRODUCTS ${CMAKE_BINARY_DIR}/LAMMPS-USER-REBOMOS-plugin-${LAMMPS_VERSION}-MSMPI.exe)
+      else()
+        add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION}-MPI rebomosplugin.nsis
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+          DEPENDS rebomosplugin ${CMAKE_BINARY_DIR}/lammps.ico ${CMAKE_BINARY_DIR}/lammps-text-logo-wide.bmp ${CMAKE_BINARY_DIR}/rebomosplugin.nsis
+          BYPRODUCTS ${CMAKE_BINARY_DIR}/LAMMPS-USER-REBOMOS-plugin-${LAMMPS_VERSION}-MPI.exe)
+      endif()
     else()
       add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION} rebomosplugin.nsis
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/USER-VCSGC/CMakeLists.txt
+++ b/USER-VCSGC/CMakeLists.txt
@@ -50,7 +50,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
       set(mytarget package)
     endif()
     if(BUILD_MPI)
-      if(USE_MSMPI)
+      if(USE_MSMPI AND CMAKE_CROSSCOMPILING)
           add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION}-MSMPI vcsgcplugin.nsis
           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
           DEPENDS vcsgcplugin ${CMAKE_BINARY_DIR}/lammps.ico ${CMAKE_BINARY_DIR}/lammps-text-logo-wide.bmp ${CMAKE_BINARY_DIR}/vcsgcplugin.nsis

--- a/USER-VCSGC/CMakeLists.txt
+++ b/USER-VCSGC/CMakeLists.txt
@@ -50,10 +50,17 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
       set(mytarget package)
     endif()
     if(BUILD_MPI)
-      add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION}-MPI vcsgcplugin.nsis
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        DEPENDS vcsgcplugin ${CMAKE_BINARY_DIR}/lammps.ico ${CMAKE_BINARY_DIR}/lammps-text-logo-wide.bmp ${CMAKE_BINARY_DIR}/aeamplugin.nsis
-        BYPRODUCTS ${CMAKE_BINARY_DIR}/LAMMPS-USER-VCSGC-plugin-${LAMMPS_VERSION}-MPI.exe)
+      if(USE_MSMPI)
+          add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION}-MSMPI vcsgcplugin.nsis
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+          DEPENDS vcsgcplugin ${CMAKE_BINARY_DIR}/lammps.ico ${CMAKE_BINARY_DIR}/lammps-text-logo-wide.bmp ${CMAKE_BINARY_DIR}/vcsgcplugin.nsis
+          BYPRODUCTS ${CMAKE_BINARY_DIR}/LAMMPS-USER-VCSGC-plugin-${LAMMPS_VERSION}-MSMPI.exe)
+      else()
+        add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION}-MPI vcsgcplugin.nsis
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+          DEPENDS vcsgcplugin ${CMAKE_BINARY_DIR}/lammps.ico ${CMAKE_BINARY_DIR}/lammps-text-logo-wide.bmp ${CMAKE_BINARY_DIR}/vcsgcplugin.nsis
+          BYPRODUCTS ${CMAKE_BINARY_DIR}/LAMMPS-USER-VCSGC-plugin-${LAMMPS_VERSION}-MPI.exe)
+      endif()
     else()
       add_custom_target(${mytarget} ${MAKENSIS_PATH} -V1 -DVERSION=${LAMMPS_VERSION} vcsgcplugin.nsis
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}


### PR DESCRIPTION
This augments the CMake scripts to be compatible with cross-compiling for the MS-MPI library instead of MPICH2